### PR TITLE
install terraform in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,6 +35,11 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
+      - name: Install terraform
+        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
+        with:
+          terraform_wrapper: false
+
       - name: Deploy
         env:
           IMAGE_VERSION: ${{ github.ref_name }}


### PR DESCRIPTION
Terraform is no longer installed in `ubuntu-latest` github actions runner by default, so installing the binary using the `hashicorp/setup-terraform` action.

https://github.com/actions/runner-images/issues/10636

> Removed from the Ubuntu 24.04 image due to maintenance reasons.

https://github.com/actions/runner-images/issues/10796#issuecomment-2422180546
https://github.com/hashicorp/setup-terraform