### PR TITLE
Format Last-Modified timestamp in cache.Set()

### DIFF
--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 	"log"
-	"sync"
+	"net/http"
 	"time"
 
 	"cloud.google.com/go/storage"
@@ -18,8 +18,7 @@ const (
 
 type Cache struct {
 	data      []byte
-	timestamp time.Time
-	mu        sync.RWMutex
+	timestamp string
 }
 
 func New() *Cache {
@@ -27,15 +26,11 @@ func New() *Cache {
 }
 
 func (c *Cache) Set(data []byte) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
 	c.data = data
-	c.timestamp = time.Now().UTC()
+	c.timestamp = time.Now().UTC().Format(http.TimeFormat)
 }
 
-func (c *Cache) Get() ([]byte, time.Time) {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
+func (c *Cache) Get() ([]byte, string) {
 	return c.data, c.timestamp
 }
 

--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -37,7 +37,8 @@ func TestCache(t *testing.T) {
 			data, timestamp := cache.Get()
 
 			require.Equal(t, tt.expected, data)
-			require.False(t, timestamp.IsZero(), "timestamp should not be empty")
+			require.NotEmpty(t, timestamp)
+			require.Contains(t, timestamp, "GMT")
 		})
 	}
 }

--- a/internal/http/handler.go
+++ b/internal/http/handler.go
@@ -20,7 +20,7 @@ func GetRepos(c *cache.Cache) http.HandlerFunc {
 		}
 
 		w.Header().Set("Content-Type", "application/json")
-		w.Header().Set("Last-Modified", timestamp.Format(http.TimeFormat))
+		w.Header().Set("Last-Modified", timestamp)
 
 		if r.Method == http.MethodHead {
 			w.WriteHeader(http.StatusOK)


### PR DESCRIPTION
Remove locking from Cache struct. It is not needed.